### PR TITLE
Remove unused private partial bitfield

### DIFF
--- a/include/quill_stroker.h
+++ b/include/quill_stroker.h
@@ -94,8 +94,6 @@ struct Stroker
         JoinStyle joinStyle : 2;
         CapStyle capStyle : 2;
 
-        unsigned int reserved : 26;
-
         Segment(SegmentType type = InvalidType,
                 float x = 0.0f,
                 float y = 0.0f,


### PR DESCRIPTION
The "reserved" part which should maybe have been called "unused" was not
initialized, which results in errors with static analysis.
Reserving the bits only makes sense when we care about binary
compatibility.
Looking at the generous use of structs, we clearly don't.