### PR TITLE
Add CMake file to expose Quill as library to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Quill is a header only library
+# make it available to CMake as quill::quill
+
+add_library(quill INTERFACE)
+add_library(quill::quill ALIAS quill)
+target_include_directories(quill INTERFACE include/)
+


### PR DESCRIPTION
Use this with add_subdirectory to make Quill available.
