### PR TITLE
Turn off -Wshadow warnings.

### DIFF
--- a/include/quill_stroker_impl.h
+++ b/include/quill_stroker_impl.h
@@ -43,19 +43,19 @@
 // #define QUILL_STROKER_NO_LINES
 
 template <typename Rasterizer, typename VaryingGenerator>
-Stroker<Rasterizer, VaryingGenerator>::Segment::Segment(SegmentType type,
-                                                        float x, float y, float width, float length,
-                                                        JoinStyle joinStyle, CapStyle capStyle,
+Stroker<Rasterizer, VaryingGenerator>::Segment::Segment(SegmentType type_,
+                                                        float x_, float y_, float width_, float length_,
+                                                        JoinStyle joinStyle_, CapStyle capStyle_,
                                                         Varyings left, Varyings right)
-    : x(x)
-    , y(y)
-    , width(width)
-    , length(length)
+    : x(x_)
+    , y(y_)
+    , width(width_)
+    , length(length_)
     , leftVarying(left)
     , rightVarying(right)
-    , type(type)
-    , joinStyle(joinStyle)
-    , capStyle(capStyle)
+    , type(type_)
+    , joinStyle(joinStyle_)
+    , capStyle(capStyle_)
 {
 }
 

--- a/include/quill_triangle_impl.h
+++ b/include/quill_triangle_impl.h
@@ -37,10 +37,10 @@
 
 
 
-inline Triangle::Triangle(Vertex a, Vertex b, Vertex c)
-    : a(a)
-    , b(b)
-    , c(c)
+inline Triangle::Triangle(Vertex a_, Vertex b_, Vertex c_)
+    : a(a_)
+    , b(b_)
+    , c(c_)
 {
 }
 

--- a/include/quill_varying.h
+++ b/include/quill_varying.h
@@ -43,20 +43,20 @@ struct VaryingNoop
 
 
 struct Varying2D {
-    Varying2D(float x = 0.0f, float y = 0.0f) : x(x), y(y) { }
+    Varying2D(float x_ = 0.0f, float y_ = 0.0f) : x(x_), y(y_) { }
     float x;
     float y;
 };
 
 struct Varying3D {
-    Varying3D(float x = 0.0f, float y = 0.0f, float z = 0.0f) : x(x), y(y), z(z) { }
+    Varying3D(float x_ = 0.0f, float y_ = 0.0f, float z_ = 0.0f) : x(x_), y(y_), z(z_) { }
     float x;
     float y;
     float z;
 };
 
 struct Varying4D {
-    Varying4D(float x = 0.0f, float y = 0.0f, float z = 0.0f, float w = 0.0f) : x(x), y(y), z(z), w(w) { }
+    Varying4D(float x_ = 0.0f, float y_ = 0.0f, float z_ = 0.0f, float w_ = 0.0f) : x(x_), y(y_), z(z_), w(w_) { }
     float x;
     float y;
     float z;

--- a/include/quill_vertex_impl.h
+++ b/include/quill_vertex_impl.h
@@ -37,9 +37,9 @@
 
 
 
-inline Vertex::Vertex(float x, float y)
-    : x(x)
-    , y(y)
+inline Vertex::Vertex(float x_, float y_)
+    : x(x_)
+    , y(y_)
 {
 }
 


### PR DESCRIPTION
While one may dispute their usefulness, they are, in fact, turned
on in many contexts and quill being header only makes them difficult
to turn off selectively.

This patch has no functional changes, only variable renaming to appease
the compiler gods.