### PR TITLE
fix: make CapStyle and JoinStyle enums uint

### DIFF
--- a/include/quill_stroker.h
+++ b/include/quill_stroker.h
@@ -34,13 +34,13 @@
 
 #pragma once
 
-enum CapStyle {
+enum CapStyle : uint8_t {
     FlatCap,
     SquareCap,
     RoundCap
 };
 
-enum JoinStyle {
+enum JoinStyle : uint8_t {
     BevelJoin,
     MiterJoin,
     RoundJoin
@@ -75,7 +75,7 @@ struct Stroker
 
     using Varyings = typename Rasterizer::Varyings;
 
-    enum SegmentType {
+    enum SegmentType : uint8_t {
         InvalidType,
         MoveToSegment,
         LineToSegment


### PR DESCRIPTION
to allow representing the largest positive enumerators

fixes warning when building with clang on Windows