### PR TITLE
fix: remove size constraint of struct members

### DIFF
--- a/include/quill_stroker.h
+++ b/include/quill_stroker.h
@@ -90,9 +90,9 @@ struct Stroker
         Varyings leftVarying;
         Varyings rightVarying;
 
-        SegmentType type : 2;
-        JoinStyle joinStyle : 2;
-        CapStyle capStyle : 2;
+        SegmentType type;
+        JoinStyle joinStyle;
+        CapStyle capStyle;
 
         Segment(SegmentType type = InvalidType,
                 float x = 0.0f,


### PR DESCRIPTION
to suppress errors that enum is too small to hold all values