### PR TITLE
bad flushes

### DIFF
--- a/include/quill_stroker_impl.h
+++ b/include/quill_stroker_impl.h
@@ -332,7 +332,7 @@ void Stroker<Rasterizer, VaryingGenerator>::cap(Line left, Line right, Segment s
 template <typename Rasterizer, typename VaryingGenerator>
 void Stroker<Rasterizer, VaryingGenerator>::flushStartCap()
 {
-    if (!m_startCapRendered && length > 0.0f) {
+    if (!m_startCapRendered && m_lastSegment.type == LineToSegment) {
         cap(m_firstLeft, m_firstRight, m_firstSegment, false);
         m_startCapRendered = true;
     }
@@ -343,7 +343,7 @@ void Stroker<Rasterizer, VaryingGenerator>::flushStartCap()
 template <typename Rasterizer, typename VaryingGenerator>
 void Stroker<Rasterizer, VaryingGenerator>::flushEndCap()
 {
-    if (!m_endCapRendered && length > 0.0f) {
+    if (!m_endCapRendered && m_lastSegment.type == LineToSegment) {
         cap(m_lastLeft, m_lastRight, m_lastSegment, true);
         m_endCapRendered = true;
     }


### PR DESCRIPTION
- fix conversion warnings
- fix: make CapStyle and JoinStyle enums uint8_t
- fix: remove size constraint of struct members
- treat initial lineTo as moveTo
- expose functions to flush start/end caps
- implement square cap
- fix startcap problem introduced with eccc66e9
