### PR TITLE
fix: missing argument to cmake_config_fixup

### DIFF
--- a/package/portfile.cmake
+++ b/package/portfile.cmake
@@ -7,6 +7,7 @@ vcpkg_cmake_install()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/share/quill/usage")
 
-vcpkg_cmake_config_fixup()
+vcpkg_cmake_config_fixup(
+  PACKAGE_NAME quill)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")


### PR DESCRIPTION
As it is, the portfile currently thinks that stuff should be installed in share/quill-stroker, but stuff is installed to share/quill

sorry for the buggy PR, I think this was missed in the rename to quill-stroker and I didn't retest after vacation.